### PR TITLE
Fixing nc.sh for Unix based systems

### DIFF
--- a/nc.sh
+++ b/nc.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-dotnet run --project ./src/nc/nc.csproj -- "$@"
+dotnet run --project ./src/Nc/Nc.csproj -- "$@"


### PR DESCRIPTION
In Unix based OSes, which use bash, file systems are generally case-sensitive. The nc.sh script on the other makes the assumption that case-insensitive file systems, like Window's NTFS or FAT32 are used. This also makes the nc.sh file executable by changing the file mode from 0644 to 0755, this was likely due to the fact that this program was developed using Windows which do not have a similar file permission system.